### PR TITLE
chore: added snt on ethereum mainnet to the status remote token list

### DIFF
--- a/nginx-proxy/static/status-token-list.json
+++ b/nginx-proxy/static/status-token-list.json
@@ -11,5 +11,13 @@
     "status",
     "remote"
   ],
-  "tokens": []
+  "tokens": [
+    {
+      "chainId": 1,
+      "address": "0x744d70FDBE2Ba4CF95131626614a1763DF805B9E",
+      "name": "Status",
+      "symbol": "SNT",
+      "decimals": 18
+    }
+  ]
 }


### PR DESCRIPTION
In order to avoid updating the code, because of the fix initially done in this PR https://github.com/status-im/status-go/pull/6619 it was decided in this chat https://discord.com/channels/1210237582470807632/1232982322874159104/1379382935811002420 to update the remote status token list and that way avoid issue for the 2.34 release.