### PR TITLE
chore: added not popular r2wbtc token on sepolia to the status remote token list

### DIFF
--- a/nginx-proxy/static/status-token-list.json
+++ b/nginx-proxy/static/status-token-list.json
@@ -13,11 +13,11 @@
   ],
   "tokens": [
     {
-      "chainId": 1,
-      "address": "0x744d70FDBE2Ba4CF95131626614a1763DF805B9E",
-      "name": "Status",
-      "symbol": "SNT",
-      "decimals": 18
+      "chainId": 11155111,
+      "address": "0x9f378c6706916cdc9310ce5a48851ec8d50a4c5b",
+      "name": "R2Credential",
+      "symbol": "R2WBTC",
+      "decimals": 8
     }
   ]
 }


### PR DESCRIPTION
It turned out that we have some rare token that doesn't collide with tokens from the other lists the app is using. More here https://discord.com/channels/1210237582470807632/1232982322874159104/1379437237502083222