### PR TITLE
fix(static)_: fix env variable injection for prod

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,6 +29,8 @@ services:
     container_name: 'market-proxy'
     volumes:
       - ./secrets/.htpasswd:/etc/nginx/.htpasswd:ro
+    env_file:
+      - .env
     restart: unless-stopped
     ports:
       - "8080:8080"

--- a/market-fetcher/Dockerfile
+++ b/market-fetcher/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM --platform=$BUILDPLATFORM golang:1.23-alpine AS builder
+FROM --platform=$BUILDPLATFORM golang:1.24-alpine AS builder
 
 WORKDIR /app
 COPY . .

--- a/start-local-prod.sh
+++ b/start-local-prod.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+
+# This script starts the production configuration locally
+# It sets MARKET_BASE_URL to the production URL to test the prod setup
+
+echo "Starting local prod environment..."
+
+if [ ! -d "./secrets" ]; then
+    mkdir -p "./secrets"
+fi
+
+if [ ! -f "./secrets/.htpasswd" ]; then
+    # Create .htpasswd with the user 'test' and password 'test'
+    echo "test:$(openssl passwd -apr1 test)" > ./secrets/.htpasswd
+fi
+
+if [ ! -f "./secrets/coingecko_api_tokens.json" ]; then
+    cat <<EOL > ./secrets/coingecko_api_tokens.json
+{
+  "api_tokens": [
+    "Coingecko-token"
+  ]
+}
+EOL
+fi
+
+# Create .env file with production MARKET_BASE_URL
+# This emulates what Ansible does on production
+echo "MARKET_BASE_URL=https://prod.market.status.im/" > .env
+
+# Stop and remove existing containers AND volumes
+docker compose -f docker-compose.yml down --volumes
+
+# Optional: remove unused volumes (for all projects)
+docker volume prune -f
+
+# Build and start containers with production configuration
+docker compose -f docker-compose.yml up --build -d
+
+echo ""
+echo "Local PROD environment started!"
+echo "API proxy: http://localhost:8080"
+echo "MARKET_BASE_URL set to: https://prod.market.status.im/"
+echo ""
+echo "Static files are available without authentication:"
+echo "- Token lists: http://localhost:8080/static/lists.json"
+echo "- Status token list: http://localhost:8080/static/status-token-list.json"
+echo ""
+echo "Check that lists.json contains prod URLs:"
+echo "curl http://localhost:8080/static/lists.json | grep -o 'prod.market.status.im'"
+echo ""
+echo "Public API endpoints (no authentication required):"
+echo "- Simple price (CoinGecko-compatible): http://localhost:8080/v1/simple/price"
+echo "- Simple prices by token ID: http://localhost:8080/v1/leaderboard/simpleprices"
+echo ""
+echo "API endpoints (require authentication - user: test, password: test):"
+echo "- Leaderboard prices: http://localhost:8080/v1/leaderboard/prices"
+echo "- Leaderboard markets: http://localhost:8080/v1/leaderboard/markets"
+echo "- Coins list: http://localhost:8080/v1/coins/list"
+echo "- Coins markets (CoinGecko-compatible): http://localhost:8080/v1/coins/markets"
+


### PR DESCRIPTION
This PR fixes the static lists of tokens served from https://prod.market.status.im/static/lists.json

Fixed the issue - the problem was that `docker-compose.yml` wasn't configured to pass environment variables from the `.env` file into the `market-proxy` container. 

Added `env_file: - .env` to the `market-proxy` service so it reads `MARKET_BASE_URL` from the `.env` file that Ansible creates on prod.

Also created `start-local-prod.sh` to test the prod configuration locally by creating a `.env` file with the production URL, which confirmed the fix works correctly.

<img width="939" height="856" alt="image" src="https://github.com/user-attachments/assets/1e64c98b-1c70-4a8d-a6d3-137f48647c75" />

fixes #60 