### PR TITLE
fix(coingecko)_: fill cache with rehypothecated market coins

### DIFF
--- a/market-fetcher/api/handlers_coins.go
+++ b/market-fetcher/api/handlers_coins.go
@@ -76,6 +76,12 @@ func (s *Server) handleCoinsMarkets(w http.ResponseWriter, r *http.Request) {
 		params.PriceChangePercentage = splitParamLowercase(priceChangeParam)
 	}
 
+	if rehypothecatedParam := r.URL.Query().Get("include_rehypothecated"); rehypothecatedParam != "" {
+		if rehypothecated, err := strconv.ParseBool(rehypothecatedParam); err == nil {
+			params.IncludeRehypothecated = rehypothecated
+		}
+	}
+
 	data, cacheStatus, err := s.marketsService.Markets(params)
 	if err != nil {
 		http.Error(w, "Failed to fetch markets data: "+err.Error(), http.StatusInternalServerError)

--- a/market-fetcher/coingecko_markets/api.go
+++ b/market-fetcher/coingecko_markets/api.go
@@ -105,6 +105,7 @@ func (c *CoinGeckoClient) executeFetchRequest(params interfaces.MarketsParams) (
 			WithIDs(params.IDs).
 			WithSparkline(params.SparklineEnabled).
 			WithPriceChangePercentage(params.PriceChangePercentage).
+			WithIncludeRehypothecated(params.IncludeRehypothecated).
 			WithCurrency(params.Currency).
 			WithApiKey(apiKey.Key, apiKey.Type)
 

--- a/market-fetcher/coingecko_markets/market_params_override.go
+++ b/market-fetcher/coingecko_markets/market_params_override.go
@@ -55,5 +55,10 @@ func ApplyParamsOverride(params interfaces.MarketsParams, cfg *config.MarketsFet
 		normalizedParams.Category = *normalize.Category
 	}
 
+	// Override include_rehypothecated if configured
+	if normalize.IncludeRehypothecated != nil {
+		normalizedParams.IncludeRehypothecated = *normalize.IncludeRehypothecated
+	}
+
 	return normalizedParams
 }

--- a/market-fetcher/coingecko_markets/markets_request_builder.go
+++ b/market-fetcher/coingecko_markets/markets_request_builder.go
@@ -82,3 +82,12 @@ func (rb *MarketsRequestBuilder) WithPriceChangePercentage(percentages []string)
 	}
 	return rb
 }
+
+// WithIncludeRehypothecated adds include_rehypothecated parameter to include
+// rehypothecated tokens (e.g., stETH, WETH, WBTC) in the response
+func (rb *MarketsRequestBuilder) WithIncludeRehypothecated(enabled bool) *MarketsRequestBuilder {
+	if enabled {
+		rb.With("include_rehypothecated", strconv.FormatBool(enabled))
+	}
+	return rb
+}

--- a/market-fetcher/coingecko_markets/markets_request_builder_test.go
+++ b/market-fetcher/coingecko_markets/markets_request_builder_test.go
@@ -247,6 +247,43 @@ func TestMarketsRequestBuilder_SpecificBehavior(t *testing.T) {
 				}
 			},
 		},
+		{
+			name: "With include_rehypothecated enabled",
+			configuration: func(rb *MarketsRequestBuilder) {
+				rb.WithIncludeRehypothecated(true)
+			},
+			checkURL: func(t *testing.T, urlStr string) {
+				parsedURL, err := url.Parse(urlStr)
+				if err != nil {
+					t.Fatalf("Failed to parse URL: %v", err)
+				}
+
+				query := parsedURL.Query()
+
+				if query.Get("include_rehypothecated") != "true" {
+					t.Errorf("Expected include_rehypothecated 'true', got %s", query.Get("include_rehypothecated"))
+				}
+			},
+		},
+		{
+			name: "With include_rehypothecated disabled",
+			configuration: func(rb *MarketsRequestBuilder) {
+				rb.WithIncludeRehypothecated(false)
+			},
+			checkURL: func(t *testing.T, urlStr string) {
+				parsedURL, err := url.Parse(urlStr)
+				if err != nil {
+					t.Fatalf("Failed to parse URL: %v", err)
+				}
+
+				query := parsedURL.Query()
+
+				// Disabled should not add the parameter
+				if query.Has("include_rehypothecated") {
+					t.Errorf("Expected no include_rehypothecated parameter when disabled, got %s", query.Get("include_rehypothecated"))
+				}
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/market-fetcher/config.yaml
+++ b/market-fetcher/config.yaml
@@ -34,6 +34,7 @@ coingecko_markets:
     sparkline: false          # never include sparkline data
     price_change_percentage: "1h,24h"  # always include 1h and 24h price changes
     category: ""              # never filter by category
+    include_rehypothecated: true       # always fetch rehypothecated tokens (stETH, WETH, WBTC)
   
   tiers:
     - name: "top-500"

--- a/market-fetcher/config/coingecko_markets_config.go
+++ b/market-fetcher/config/coingecko_markets_config.go
@@ -14,6 +14,7 @@ type MarketParamsNormalize struct {
 	Sparkline             *bool   `yaml:"sparkline,omitempty"`
 	PriceChangePercentage *string `yaml:"price_change_percentage,omitempty"`
 	Category              *string `yaml:"category,omitempty"`
+	IncludeRehypothecated *bool   `yaml:"include_rehypothecated,omitempty"`
 }
 
 // MarketTier defines a tier configuration for token pages

--- a/market-fetcher/interfaces/coingecko_markets.go
+++ b/market-fetcher/interfaces/coingecko_markets.go
@@ -48,6 +48,9 @@ type MarketsParams struct {
 
 	// PriceChangePercentage includes price change percentages for specific time periods
 	PriceChangePercentage []string `json:"price_change_percentage,omitempty"`
+
+	// IncludeRehypothecated includes rehypothecated tokens (e.g., stETH, WETH, WBTC) in the response
+	IncludeRehypothecated bool `json:"include_rehypothecated,omitempty"`
 }
 
 // MarketsResponse represents markets data response structure

--- a/start-local.sh
+++ b/start-local.sh
@@ -22,6 +22,12 @@ if [ ! -f "./secrets/coingecko_api_tokens.json" ]; then
 EOL
 fi
 
+# Create .env file with proxy credentials for frontend (always recreate to ensure correct values)
+cat <<EOL > ./.env
+MARKET_PROXY_USER=test
+MARKET_PROXY_PASSWORD=test
+EOL
+
 # Stop and remove existing containers AND volumes
 docker compose -f docker-compose.local.yml down --volumes
 


### PR DESCRIPTION
CoinGecko is introducing breaking API changes on February 4, 2026. 
Rehypothecated tokens (stETH, WETH, WBTC) will be excluded from `/coins/markets` responses by default.

This PR adds:
New `include_rehypothecated` query parameter support in the HTTP handler
Config override to always fetch rehypothecated tokens during cache warming

The proxy now always fetches complete data including rehypothecated tokens, ensuring users receive full market data from cache.
